### PR TITLE
make "environment" set the same default tag

### DIFF
--- a/locals-tags.tf
+++ b/locals-tags.tf
@@ -1,6 +1,6 @@
 locals {
-  default_tags = var.default_tags_enabled ? {
-    env   = var.environment
-    stack = var.stack
+  default_tags  = var.default_tags_enabled ? {
+    environment = var.environment
+    stack       = var.stack
   } : {}
 }


### PR DESCRIPTION
Fixes #5  .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- this will just allow for the "environment"  input to generate by default an **environment** tag, rather than an **env** tag
-
-

@claranet/fr-azure-reviewers
